### PR TITLE
fix(3D_model_path):修复封装中的3D封装路径属性的默认导出路径

### DIFF
--- a/EasyKiConverter/Web_Ui/app.py
+++ b/EasyKiConverter/Web_Ui/app.py
@@ -453,7 +453,7 @@ def export_component_real_threadsafe(lcsc_id: str, export_path: str, export_opti
                     f"{footprint_data.info.name}.kicad_mod"
                 )
                 
-                model_3d_path = lib_name  # 与main.py一致
+                model_3d_path = output_base  # 使用完整的用户导出路径 + lib_name
                 footprint_exporter.export(
                     footprint_full_path=footprint_filename,
                     model_3d_path=model_3d_path

--- a/EasyKiConverter/Web_Ui/user_config.json
+++ b/EasyKiConverter/Web_Ui/user_config.json
@@ -1,5 +1,5 @@
 {
-  "output_folder_path": "",
+  "output_folder_path": "/home/dennis/Desktop/test",
   "output_lib_name": "test",
   "export_options": {
     "symbol": true,

--- a/EasyKiConverter/kicad/export_kicad_3d_model.py
+++ b/EasyKiConverter/kicad/export_kicad_3d_model.py
@@ -47,7 +47,7 @@ def get_vertices(obj_data: str) -> list:
     matchs = re.findall(pattern=vertices_regex, string=obj_data, flags=re.DOTALL)
 
     return [
-        " ".join([str(round(float(coord) / 2.54, 4)) for coord in vertice.split(" ")])
+        " ".join([str(round(float(coord), 4)) for coord in vertice.split(" ")])
         for vertice in matchs
     ]
 

--- a/EasyKiConverter/kicad/export_kicad_3d_model.py
+++ b/EasyKiConverter/kicad/export_kicad_3d_model.py
@@ -47,7 +47,7 @@ def get_vertices(obj_data: str) -> list:
     matchs = re.findall(pattern=vertices_regex, string=obj_data, flags=re.DOTALL)
 
     return [
-        " ".join([str(round(float(coord), 4)) for coord in vertice.split(" ")])
+        " ".join([str(round(float(coord) / 2.54, 4)) for coord in vertice.split(" ")])
         for vertice in matchs
     ]
 
@@ -85,7 +85,7 @@ def generate_wrl_model(model_3d: Ee3dModel) -> Ki3dModel:
             f"""
             Shape{{
                 appearance Appearance {{
-                    material  Material 	{{
+                    material  Material {{
                         diffuseColor {' '.join(material['diffuse_color'])}
                         specularColor {' '.join(material['specular_color'])}
                         ambientIntensity 0.2

--- a/EasyKiConverter/kicad/export_kicad_footprint.py
+++ b/EasyKiConverter/kicad/export_kicad_footprint.py
@@ -541,8 +541,10 @@ class ExporterFootprintKicad:
             ki_lib += KI_TEXT.format(**vars(text))
 
         if ki.model_3d is not None:
+            # 构建3D模型路径：用户导出路径 + 库名.3dshapes/模型名.wrl
+            # Build 3D model path: user export path + lib_name.3dshapes/model_name.wrl
             ki_lib += KI_MODEL_3D.format(
-                file_3d=f"{model_3d_path}/{ki.model_3d.name}.wrl",
+                file_3d=f"{model_3d_path}.3dshapes/{ki.model_3d.name}.wrl",
                 pos_x=ki.model_3d.translation.x,
                 pos_y=ki.model_3d.translation.y,
                 pos_z=ki.model_3d.translation.z,


### PR DESCRIPTION
- 修复封装中的3D封装路径属性的默认导出路径
- linux中的kicad的3D封装可能会显示异常，但是windows是正常的，该问题未排查到位